### PR TITLE
MNT: add a prefix to the dark-subtracted images

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -308,7 +308,8 @@ def factory(name, start_doc):
 
     def subfactory(name, descriptor_doc):
         if descriptor_doc['name'] == 'primary':
-            serializer = suitcase.tiff_series.Serializer('exported/')
+            serializer = suitcase.tiff_series.Serializer('exported/',
+                    file_prefix='SUB-{start[uid]}-')
             serializer('start', start_doc)
             serializer('descriptor', descriptor_doc)
             return [serializer]


### PR DESCRIPTION
This is to the the same-styled file names for the dark-subtracted images:
```
RAW-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-dark-det_img-0.tiff
RAW-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-0.tiff
RAW-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-1.tiff
RAW-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-2.tiff
RAW-f7d0ae1c-94bc-490d-9020-54c52730eacb-dark-det_img-0.tiff
RAW-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-0.tiff
RAW-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-1.tiff
RAW-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-2.tiff
SUB-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-0.tiff
SUB-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-1.tiff
SUB-d25683bb-cbdc-4fae-b2b5-b8e5464c6b7c-primary-det_img-2.tiff
SUB-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-0.tiff
SUB-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-1.tiff
SUB-f7d0ae1c-94bc-490d-9020-54c52730eacb-primary-det_img-2.tiff
```